### PR TITLE
unpin GPU

### DIFF
--- a/ImageFaceRecognise.py
+++ b/ImageFaceRecognise.py
@@ -30,8 +30,6 @@ class ImageFaceRecognise:
                  detector_weights=''):
         
         utils.auto_init_args(self)
-
-        os.environ['CUDA_VISIBLE_DEVICES'] = str(self.gpu)
         print("Using GPUs: ", os.environ['CUDA_VISIBLE_DEVICES'])
 
         # ================================================================================================

--- a/VideoFaceTracker.py
+++ b/VideoFaceTracker.py
@@ -34,7 +34,6 @@ class VideoFaceTracker:
         utils.auto_init_args(self)
         
         self.OG_temp_dir = copy.deepcopy(self.temp_dir)
-        os.environ['CUDA_VISIBLE_DEVICES'] = str(self.gpu)
         
         print("Using GPUs: ", os.environ['CUDA_VISIBLE_DEVICES'])
 


### PR DESCRIPTION
Due to unexposed `--gpu` arg, GPU is always pinned to 0
I've left it to the user to choose. Alternatively, I can expose the arg to all models. 